### PR TITLE
fix: remove dependency on nvim-treesitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ starting `e`.
 # Requirements
 
 - NeoVim `main`, 0.9.5 _might_ also work but I haven't verified this
-- [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter/)
 
 # Installation
 

--- a/lua/tree-pairs/init.lua
+++ b/lua/tree-pairs/init.lua
@@ -1,7 +1,6 @@
 local api = vim.api
 local ts = vim.treesitter
 local fn = vim.fn
-local parsers = require('nvim-treesitter.parsers')
 local M = {}
 local AUGROUP = api.nvim_create_augroup('tree-pairs', {})
 


### PR DESCRIPTION
It is no longer needed anyway :+1: